### PR TITLE
Allow simplification of path definition as a simple list of functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ This project was borne out of a desire to support directed-graph workflows on FA
 At its most basic, your lambda would require no more than this.
 
 ```python
-from lpipe import Action, QueueType, process_event
+import lpipe
 
 def test_func(foo: str, **kwargs):
 	pass
 
-PATHS = {"EXAMPLE": [Action(functions=[test_func])]}
-
 def lambda_handler(event, context):
-    return process_event(
+    return lpipe.process_event(
         event=event,
         context=context,
-        paths=PATHS,
-        queue_type=QueueType.SQS,
+        paths={
+            "EXAMPLE": [test_func]
+        },
+        queue_type=lpipe.QueueType.SQS,
     )
 ```
 

--- a/dummy_lambda/func/main.py
+++ b/dummy_lambda/func/main.py
@@ -92,6 +92,7 @@ class Path(Enum):
     TEST_MULTI_TRIGGER = 17
     TEST_DEFAULT_PATH = 18
     TEST_DEFAULT_PATH_INCLUDE_ALL = 19
+    TEST_BARE_FUNCS = 20
 
 
 PATHS = {
@@ -115,6 +116,7 @@ PATHS = {
         Action(functions=[test_func_no_params], paths=[Path.TEST_FUNC_BLANK_PARAMS]),
         Action(paths=[Path.TEST_FUNC_BLANK_PARAMS]),
     ],
+    Path.TEST_BARE_FUNCS: [test_func, test_func_no_params],
     Path.TEST_RENAME_PARAM: [
         Action(
             required_params=[

--- a/lpipe/pipeline.py
+++ b/lpipe/pipeline.py
@@ -6,7 +6,7 @@ import warnings
 from collections import defaultdict, namedtuple
 from enum import Enum, EnumMeta
 from types import FunctionType
-from typing import Callable, Union, get_type_hints
+from typing import Union, get_type_hints
 
 from decouple import config
 
@@ -289,7 +289,7 @@ def execute_payload(
 
     if isinstance(payload.path, Enum):  # PATH
         # Allow someone to simplify their definition of a Path to a list of functions.
-        if all([isinstance(f, Callable) for f in paths[payload.path]]):
+        if all([isinstance(f, FunctionType) for f in paths[payload.path]]):
             paths[payload.path] = [Action(functions=action)]
 
         for action in paths[payload.path]:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -45,6 +45,10 @@ DATA = {
         "payload": [{"path": "MULTI_TEST_FUNC_NO_PARAMS", "kwargs": {}}],
         "response": {"stats": {"received": 1, "successes": 1}},
     },
+    "TEST_BARE_FUNCS": {
+        "payload": [{"path": "TEST_FUNC", "kwargs": {"foo": "bar"}}],
+        "response": {"stats": {"received": 1, "successes": 1}},
+    },
     "RENAME_PARAM": {
         "payload": [{"path": "TEST_RENAME_PARAM", "kwargs": {"bar": "bar"}}],
         "response": {"stats": {"received": 1, "successes": 1}},

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -358,7 +358,9 @@ class TestProcessEvents:
 
         # Simulate a PATHS dictionary where the user didn't define and use an enumeration.
         _PATHS = {
-            str(path).split(".")[-1]: [a.copy() for a in actions]
+            str(path).split(".")[-1]: [
+                a.copy() if isinstance(a, Action) else a for a in actions
+            ]
             for path, actions in deepcopy(PATHS).items()
         }
 


### PR DESCRIPTION
A simple path with one action
```python
PATHS = {
    "EXAMPLE": [
        Action(functions=[test_func, test_func2])
    ]
}
```
may now also be defined as
```python
PATHS = {
    "EXAMPLE": [test_func, test_func2]
}
```