### PR TITLE
Make 'path' an optional argument for Queue() so that messages may be sent to non-lpipe lambdas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lpipe 
+# lpipe
 [![PyPI version](https://img.shields.io/pypi/v/lpipe.svg)](https://pypi.org/project/lpipe/) [![TravisCI build status](https://travis-ci.com/mintel/lpipe.svg?branch=master)](https://travis-ci.com/github/mintel/lpipe) [![Code Coverage](https://img.shields.io/codecov/c/github/mintel/lpipe.svg)](https://codecov.io/gh/mintel/lpipe)
 
 **lpipe** provides a simple set of tools for writing clearly defined, multi-function AWS Lambdas in Python.
@@ -207,7 +207,7 @@ lpipe.Queue(type, name, path)
 | `type` | `lpipe.pipeline.QueueType` | |
 | `name` | `str` | Name/identifier of the queue (used by `QueueType.Kinesis`, `QueueType.SQS`) If you include name instead of url for an SQS queue, the queue URL will fetched automatically. |
 | `url`  | `str` | URL/URI of the queue (used by `QueueType.SQS`) |
-| `path` | `str` | A path name, usually to trigger a path in the lambda feeding off of this queue. |
+| `path` | `str` | (optional) A path name, usually to trigger a path in the lambda feeding off of this queue. If this is set, the sent message will be in the standard lpipe format of `{"path": "", "kwargs": {}}`.|
 
 ##### Example
 

--- a/dummy_lambda/func/main.py
+++ b/dummy_lambda/func/main.py
@@ -86,18 +86,19 @@ class Path(Enum):
     MULTI_TEST_FUNC = 8
     MULTI_TEST_FUNC_NO_PARAMS = 9
     TEST_RENAME_PARAM = 10
-    TEST_KINESIS_PATH = 11
-    TEST_SQS_PATH = 12
-    TEST_SENTRY = 13
-    TEST_RET = 14
-    TEST_TRIGGER_FIRST = 15
-    TEST_TRIGGER_SECOND = 16
-    TEST_MULTI_TRIGGER = 17
-    TEST_TRIGGER_ERROR = 18
-    TEST_DEFAULT_PATH = 19
-    TEST_DEFAULT_PATH_INCLUDE_ALL = 20
-    TEST_BARE_FUNCS = 21
-    TEST_RAISE = 22
+    TEST_KINESIS_QUEUE = 11
+    TEST_SQS_QUEUE = 12
+    TEST_SQS_QUEUE_WITHOUT_PATH = 13
+    TEST_SENTRY = 14
+    TEST_RET = 15
+    TEST_TRIGGER_FIRST = 16
+    TEST_TRIGGER_SECOND = 17
+    TEST_MULTI_TRIGGER = 18
+    TEST_TRIGGER_ERROR = 19
+    TEST_DEFAULT_PATH = 20
+    TEST_DEFAULT_PATH_INCLUDE_ALL = 21
+    TEST_BARE_FUNCS = 22
+    TEST_RAISE = 23
 
 
 PATHS = {
@@ -130,7 +131,7 @@ PATHS = {
             functions=[test_func],
         )
     ],
-    Path.TEST_KINESIS_PATH: [
+    Path.TEST_KINESIS_QUEUE: [
         Action(
             required_params=["uri"],
             paths=[
@@ -142,7 +143,7 @@ PATHS = {
             ],
         )
     ],
-    Path.TEST_SQS_PATH: [
+    Path.TEST_SQS_QUEUE: [
         Action(
             required_params=["uri"],
             paths=[
@@ -150,6 +151,12 @@ PATHS = {
                     name=config("TEST_SQS_QUEUE"), type=QueueType.SQS, path="TEST_FUNC"
                 )
             ],
+        )
+    ],
+    Path.TEST_SQS_QUEUE_WITHOUT_PATH: [
+        Action(
+            required_params=["uri"],
+            paths=[Queue(name=config("TEST_SQS_QUEUE"), type=QueueType.SQS)],
         )
     ],
     Path.TEST_FUNC_DEFAULT_PARAM: [Action(functions=[test_func_default_param])],

--- a/lpipe/contrib/__init__.py
+++ b/lpipe/contrib/__init__.py
@@ -1,1 +1,3 @@
+# flake8: noqa
+
 from . import boto3, kinesis, mindictive, sentry, sqs

--- a/lpipe/pipeline.py
+++ b/lpipe/pipeline.py
@@ -253,7 +253,11 @@ def execute_payload(
             }
         ):
             logger.log("Pushing record.")
-        put_record(queue=queue, record={"path": queue.path, "kwargs": payload.kwargs})
+        if queue.path:
+            record = {"path": queue.path, "kwargs": payload.kwargs}
+        else:
+            record = payload.kwargs
+        put_record(queue=queue, record=record)
     else:
         logger.info(
             f"Path should be a string (path name), Path (path Enum), or Queue: {payload.path})"

--- a/lpipe/queue.py
+++ b/lpipe/queue.py
@@ -31,7 +31,7 @@ class Queue:
     """
 
     def __init__(
-        self, type: queue.QueueType, path: str, name: str = None, url: str = None
+        self, type: queue.QueueType, path: str = None, name: str = None, url: str = None
     ):
         assert name or url
         assert isinstance(type, queue.QueueType)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import logging
 
 import boto3_fixtures as b3f
-import moto
 import pytest
 from tests import fixtures
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -66,11 +66,15 @@ DATA = {
         "response": {"stats": {"received": 1, "successes": 1}},
     },
     "KINESIS_OUTPUT": {
-        "payload": [{"path": "TEST_KINESIS_PATH", "kwargs": {"uri": "foo"}}],
+        "payload": [{"path": "TEST_KINESIS_QUEUE", "kwargs": {"uri": "foo"}}],
         "response": {"stats": {"received": 1, "successes": 1}},
     },
     "SQS_OUTPUT": {
-        "payload": [{"path": "TEST_SQS_PATH", "kwargs": {"uri": "foo"}}],
+        "payload": [{"path": "TEST_SQS_QUEUE", "kwargs": {"uri": "foo"}}],
+        "response": {"stats": {"received": 1, "successes": 1}},
+    },
+    "SQS_OUTPUT_NO_PATH": {
+        "payload": [{"path": "TEST_SQS_QUEUE_WITHOUT_PATH", "kwargs": {"uri": "foo"}}],
         "response": {"stats": {"received": 1, "successes": 1}},
     },
     "DEFAULT_PARAM": {


### PR DESCRIPTION
Previously, queue required that the `path` variable be provided. When used by a path/payload , `pipeline.execute_payload` would send an lpipe-ready message to the subsequent queue.
```python
my_queue = Queue(
    type=QueueType.SQS,
    url=my_queue_url,
    path="EXAMPLE_PATH"
)

def my_function(**kwargs):
    return Payload(
        path=my_queue,
        kwargs={"foo": "bar"}
    )

# lpipe will send the following message...
{"path": "EXAMPLE_PATH", "kwargs": {"foo": "bar"}}
```

This MR allows you to send kwargs at the root level of the message, which is especially useful if you want to send messages to a queue read by a service which doesn't use lpipe.

```python
my_queue = Queue(
    type=QueueType.SQS,
    url=my_queue_url,
    # path="EXAMPLE_PATH" <-- no longer a required argument
)

# When used in a payload as demonstrated above, the following message will be sent...
{"foo": "bar"}
```
