### PR TITLE
Add EventSourceType and parse_event() generator

### DIFF
--- a/lpipe/__init__.py
+++ b/lpipe/__init__.py
@@ -10,5 +10,5 @@ Lambda Pipeline, a framework for writing clear, minimal Python FAAS
 from lpipe._version import __version__
 from lpipe.action import Action
 from lpipe.payload import Payload
-from lpipe.pipeline import process_event
+from lpipe.pipeline import EventSourceType, process_event
 from lpipe.queue import Queue, QueueType

--- a/lpipe/pipeline.py
+++ b/lpipe/pipeline.py
@@ -88,15 +88,14 @@ def parse_record(
     state: State, record: Any, event_source: str, default_path: Union[str, Enum] = None
 ) -> Payload:
     try:
+        kwargs = {"event_source": event_source}
         if not default_path:
             for field in ["path", "kwargs"]:
                 assert field in record
-        payload = Payload(
-            path=default_path if default_path else record["path"],
-            kwargs=record if default_path else record["kwargs"],
-            event_source=event_source,
-        ).validate(state.path_enum)
-        return payload
+            kwargs.update({"path": record["path"], "kwargs": record["kwargs"]})
+        else:
+            kwargs.update({"path": default_path, "kwargs": record})
+        return Payload(**kwargs).validate(state.path_enum)
     except AssertionError as e:
         raise lpipe.exceptions.InvalidPayloadError(
             "'path' or 'kwargs' missing from payload."

--- a/lpipe/queue.py
+++ b/lpipe/queue.py
@@ -4,9 +4,8 @@ from lpipe import queue, utils
 
 
 class QueueType(Enum):
-    RAW = 1  # This may be a Cloudwatch or manually triggered event
-    KINESIS = 2
-    SQS = 3
+    KINESIS = 1
+    SQS = 2
 
 
 class Queue:


### PR DESCRIPTION
Represent event source type as EventSourceType instead of using QueueType everywhere. Generate records from event using generator parse_event()

```python
event_source_type = lpipe.EventSourceType.SQS

for encoded_record, decoded_record, event_source in parse_event(event, event_source_type):
    print(decoded_record)
```