### PR TITLE
Simplify exception capture inside return_handler

### DIFF
--- a/dummy_lambda/func/main.py
+++ b/dummy_lambda/func/main.py
@@ -5,10 +5,18 @@ from enum import Enum
 from decouple import config
 
 from lpipe import Action, Payload, Queue, QueueType, process_event
-from lpipe.exceptions import FailButContinue
+from lpipe.exceptions import FailButContinue, FailCatastrophically
 
 # from lpipe.contrib import sentry
 # sentry.init()
+
+
+class MyCustomException(FailCatastrophically):
+    pass
+
+
+class MyCustomExceptionContinue(FailButContinue):
+    pass
 
 
 def test_func(foo: str, logger, state, payload, **kwargs):
@@ -50,7 +58,7 @@ def test_func_multi_trigger(logger, **kwargs):
 
 
 def test_func_trigger_error(logger, **kwargs):
-    return Payload(path=Path.TEST_RAISE, kwargs={})
+    return Payload(path=Path.TEST_RAISE_CUSTOM_CONTINUE, kwargs={})
 
 
 def return_foobar(**kwargs):
@@ -73,6 +81,22 @@ def test_kwargs_passed_to_default_path(foo, logger, state, **kwargs):
 
 def throw_exception(**kwargs):
     raise Exception()
+
+
+def throw_custom_exception(**kwargs):
+    raise MyCustomException("error message")
+
+
+def throw_custom_exception_continue(**kwargs):
+    raise MyCustomExceptionContinue("error message (continue)")
+
+
+def return_payload_throw_custom_exception(**kwargs):
+    return Payload(path=Path.TEST_RAISE_CUSTOM, kwargs={})
+
+
+def return_payload_throw_custom_exception_continue(**kwargs):
+    return Payload(path=Path.TEST_RAISE_CUSTOM_CONTINUE, kwargs={})
 
 
 #     try:
@@ -106,6 +130,10 @@ class Path(Enum):
     TEST_DEFAULT_PATH_INCLUDE_ALL = 21
     TEST_BARE_FUNCS = 22
     TEST_RAISE = 23
+    TEST_RAISE_CUSTOM = 24
+    TEST_RAISE_CUSTOM_CONTINUE = 25
+    TEST_RETURN_PAYLOAD_RAISES = 26
+    TEST_RETURN_PAYLOAD_RAISES_CONTINUE = 27
 
 
 PATHS = {
@@ -181,6 +209,12 @@ PATHS = {
     ],
     Path.TEST_TRIGGER_ERROR: [test_func_trigger_error],
     Path.TEST_RAISE: [throw_exception],
+    Path.TEST_RAISE_CUSTOM: [throw_custom_exception],
+    Path.TEST_RAISE_CUSTOM_CONTINUE: [throw_custom_exception_continue],
+    Path.TEST_RETURN_PAYLOAD_RAISES: [return_payload_throw_custom_exception],
+    Path.TEST_RETURN_PAYLOAD_RAISES_CONTINUE: [
+        return_payload_throw_custom_exception_continue
+    ],
 }
 
 

--- a/lpipe/pipeline.py
+++ b/lpipe/pipeline.py
@@ -317,8 +317,6 @@ def execute_action(payload: Payload, action: Action, state: State) -> Any:
                 f"Skipped {payload.path.name} {f.__name__} due to unhandled Exception {e.__class__.__name__}. This is very serious; please update your function to handle this."
             )
             log_exception(state, e)
-            if state.debug:
-                raise lpipe.exceptions.FailCatastrophically() from e
 
     payloads = []
     for _path in action.paths:
@@ -366,11 +364,9 @@ def return_handler(ret: Any, state: State) -> Any:
         state.logger.debug(f"executing dynamic payload: {p}")
         try:
             ret = execute_payload(payload=p, state=state)
-        except Exception as e:
-            state.logger.debug(utils.exception_to_str(e))
-            raise lpipe.exceptions.FailButContinue(
-                f"Failed to execute returned Payload: {p}"
-            ) from e
+        except Exception:
+            state.logger.error(f"Failed to execute returned {p}")
+            raise
     return ret
 
 

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -229,6 +229,21 @@ def test_fail_catastrophically(set_environment):
         )
 
 
+def test_returned_payload_execution_error(set_environment):
+    from dummy_lambda.func.main import PATHS, Path
+
+    with pytest.raises(exceptions.FailCatastrophically):
+        response = process_event(
+            event=[{"foo": "bar"}],
+            context=b3f.awslambda.MockContext(function_name=config("FUNCTION_NAME")),
+            path_enum=Path,
+            paths=PATHS,
+            event_source_type=EventSourceType.RAW,
+            default_path=Path.TEST_RETURN_PAYLOAD_RAISES,
+        )
+        b3f.utils.emit_logs(response)
+
+
 @pytest.mark.usefixtures("sqs", "kinesis")
 class TestProcessEvents:
     @pytest.mark.parametrize(
@@ -255,7 +270,7 @@ class TestProcessEvents:
             path_enum=Path,
             paths=PATHS,
             event_source_type=event["type"],
-            debug=True,
+            debug=False,
             exception_handler=exception_handler,
             **kwargs
         )


### PR DESCRIPTION
Simplify exception capture inside return_handler to avoid unique, unexpected behavior. Remove debug=True cast of unknown exceptions to FailCatastrophically, and change log level in return_handler from debug to error"
